### PR TITLE
Theme-aware popups and a shared modal primitive

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -613,58 +613,7 @@ body.drag-over #dropZone { opacity: 1; }
     min-height: 0;
 }
 
-/* ========== Help / keyboard shortcuts overlay ========== */
-
-#helpOverlay {
-    /* Palette comes from the theme via the --popup-* tokens (see :root). */
-    --help-accent: var(--popup-accent);
-    position: fixed;
-    inset: 0;
-    background: var(--popup-backdrop);
-    backdrop-filter: blur(2px);
-    display: none;
-    align-items: center;
-    justify-content: center;
-    z-index: 2500;
-}
-
-#helpOverlay.visible { display: flex; }
-
-.help-card {
-    background: var(--popup-bg);
-    border: 2px solid var(--popup-border);
-    border-radius: 8px;
-    box-shadow: 6px 6px 0 var(--popup-shadow);
-    min-width: min(560px, 92vw);
-    max-width: 92vw;
-    max-height: 86vh;
-    overflow: auto;
-    padding: 20px 24px;
-    color: var(--popup-fg);
-    font-family: inherit;
-}
-
-.help-card h2 {
-    margin: 0 0 12px;
-    font-size: 16px;
-    color: var(--help-accent);
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-}
-
-.help-card .help-close {
-    background: transparent;
-    border: 1px solid var(--popup-border);
-    color: var(--popup-fg);
-    border-radius: 3px;
-    width: 28px;
-    height: 28px;
-    font-size: 14px;
-    cursor: pointer;
-}
-.help-card .help-close:hover { background: var(--popup-surface); }
+/* ========== Help / keyboard shortcuts ========== */
 
 .help-list {
     list-style: none;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -556,6 +556,63 @@ body.drag-over #dropZone { opacity: 1; }
     color: var(--popup-muted);
 }
 
+/* ========== Modal shell (modal.js) ========== */
+/* Every popup dialog shares this shell; palette from the --popup-* tokens. */
+
+.modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: var(--popup-backdrop);
+    backdrop-filter: blur(2px);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 2500;
+}
+.modal-overlay.visible { display: flex; }
+
+.modal-card {
+    background: var(--popup-bg);
+    border: 2px solid var(--popup-border);
+    border-radius: 8px;
+    box-shadow: 6px 6px 0 var(--popup-shadow);
+    width: var(--modal-width, min(560px, 92vw));
+    max-width: 92vw;
+    max-height: 86vh;
+    display: flex;
+    flex-direction: column;
+    padding: 20px 24px;
+    color: var(--popup-fg);
+    font-family: inherit;
+}
+.modal-title {
+    margin: 0 0 12px;
+    font-size: 16px;
+    color: var(--popup-accent);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+.modal-close {
+    background: transparent;
+    border: 1px solid var(--popup-border);
+    color: var(--popup-fg);
+    border-radius: 3px;
+    width: 28px;
+    height: 28px;
+    font-size: 14px;
+    cursor: pointer;
+    flex: 0 0 auto;
+}
+.modal-close:hover { background: var(--popup-surface); }
+.modal-close:focus-visible, .modal-card a:focus-visible { outline: 2px solid var(--popup-accent); outline-offset: 2px; }
+
+.modal-body {
+    overflow: auto;
+    min-height: 0;
+}
+
 /* ========== Help / keyboard shortcuts overlay ========== */
 
 #helpOverlay {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -42,6 +42,21 @@ html, body {
 
 body { overflow: hidden; }
 
+/* Popup palette derived from the theme's tracker tokens so dialogs and toasts
+   match whatever theme is active (light themes get light cards). */
+:root {
+    --popup-bg:      var(--tracker-bg);
+    --popup-fg:      var(--tracker-fg);
+    --popup-accent:  var(--accent);
+    --popup-border:  color-mix(in srgb, var(--tracker-fg) 28%, var(--tracker-bg));
+    --popup-surface: color-mix(in srgb, var(--tracker-fg) 9%, var(--tracker-bg));
+    --popup-muted:   color-mix(in srgb, var(--tracker-fg) 58%, transparent);
+    --popup-faint:   color-mix(in srgb, var(--tracker-fg) 35%, transparent);
+    --popup-shadow:  color-mix(in srgb, var(--tracker-fg) 35%, transparent);
+    --popup-backdrop: color-mix(in srgb, var(--tracker-bg) 55%, rgba(0, 0, 0, 0.55));
+}
+
+
 .app {
     padding: 16px;
     display: flex;
@@ -472,13 +487,13 @@ html.samples-hidden .sample-section    { display: none; }
     bottom: 16px;
     left: 50%;
     transform: translate(-50%, 100%);
-    background: #1f2937;
-    color: #ffffff;
-    border: 2px solid #4a4a4a;
+    background: var(--popup-bg);
+    color: var(--popup-fg);
+    border: 2px solid var(--popup-border);
     border-radius: 4px;
     padding: 10px 16px;
-    box-shadow: 3px 3px 0 #000;
-    font-family: monospace;
+    box-shadow: 3px 3px 0 var(--popup-shadow);
+    font-family: inherit;
     font-size: 13px;
     max-width: min(90vw, 480px);
     opacity: 0;
@@ -514,14 +529,14 @@ html.samples-hidden .sample-section    { display: none; }
 body.drag-over #dropZone { opacity: 1; }
 
 .drop-zone-card {
-    background: #1f2937;
-    border: 3px dashed var(--accent);
+    background: var(--popup-bg);
+    border: 3px dashed var(--popup-accent);
     border-radius: 12px;
     padding: 32px 56px;
     text-align: center;
-    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.6);
-    font-family: monospace;
-    color: #ffffff;
+    box-shadow: 0 12px 40px var(--popup-shadow);
+    font-family: inherit;
+    color: var(--popup-fg);
 }
 
 .drop-zone-card i {
@@ -538,19 +553,18 @@ body.drag-over #dropZone { opacity: 1; }
 
 .drop-zone-hint {
     font-size: 13px;
-    color: #9ca3af;
+    color: var(--popup-muted);
 }
 
 /* ========== Help / keyboard shortcuts overlay ========== */
 
 #helpOverlay {
-    /* Popup palette is intentionally theme-independent (dark backdrop, hardcoded
-       chrome). `--help-accent` is the lone "lively" colour used by the title and
-       the footer links so it contrasts with the dark card in every theme. */
-    --help-accent: #facc15;
+    /* Palette comes from the theme via the --popup-* tokens (see :root). */
+    --help-accent: var(--popup-accent);
     position: fixed;
     inset: 0;
-    background: rgba(0, 0, 0, 0.78);
+    background: var(--popup-backdrop);
+    backdrop-filter: blur(2px);
     display: none;
     align-items: center;
     justify-content: center;
@@ -560,17 +574,17 @@ body.drag-over #dropZone { opacity: 1; }
 #helpOverlay.visible { display: flex; }
 
 .help-card {
-    background: #1f2937;
-    border: 2px solid #4a4a4a;
+    background: var(--popup-bg);
+    border: 2px solid var(--popup-border);
     border-radius: 8px;
-    box-shadow: 6px 6px 0 #000;
+    box-shadow: 6px 6px 0 var(--popup-shadow);
     min-width: min(560px, 92vw);
     max-width: 92vw;
     max-height: 86vh;
     overflow: auto;
     padding: 20px 24px;
-    color: #ffffff;
-    font-family: monospace;
+    color: var(--popup-fg);
+    font-family: inherit;
 }
 
 .help-card h2 {
@@ -585,15 +599,15 @@ body.drag-over #dropZone { opacity: 1; }
 
 .help-card .help-close {
     background: transparent;
-    border: 1px solid #4a4a4a;
-    color: #ffffff;
+    border: 1px solid var(--popup-border);
+    color: var(--popup-fg);
     border-radius: 3px;
     width: 28px;
     height: 28px;
     font-size: 14px;
     cursor: pointer;
 }
-.help-card .help-close:hover { background: #4a4a4a; }
+.help-card .help-close:hover { background: var(--popup-surface); }
 
 .help-list {
     list-style: none;
@@ -607,36 +621,36 @@ body.drag-over #dropZone { opacity: 1; }
 }
 
 .help-list dt {
-    color: #facc15;
+    color: var(--popup-accent);
     text-align: right;
     white-space: nowrap;
 }
 
 .help-list dd {
     margin: 0;
-    color: #e5e7eb;
+    color: var(--popup-fg);
 }
 
 .help-credits {
     margin-top: 16px;
     padding-top: 10px;
-    border-top: 1px solid #2a2a2a;
+    border-top: 1px solid var(--popup-border);
     font-size: 10px;
     line-height: 1.6;
-    color: #6b7280;
+    color: var(--popup-muted);
     text-align: center;
 }
 .help-credits a {
-    color: #9ca3af;
+    color: var(--popup-fg);
     text-decoration: none;
-    border-bottom: 1px dotted #4a4a4a;
+    border-bottom: 1px dotted var(--popup-border);
 }
 .help-credits a:hover,
 .help-credits a:focus-visible {
     color: var(--help-accent);
     border-bottom-color: currentColor;
 }
-.help-credits-license { color: #4a4a4a; }
+.help-credits-license { color: var(--popup-faint); }
 
 .help-credits .help-home {
     margin-bottom: 10px;
@@ -677,14 +691,14 @@ body.drag-over #dropZone { opacity: 1; }
 
 kbd {
     display: inline-block;
-    background: #2a2a2a;
-    border: 1px solid #4a4a4a;
+    background: var(--popup-surface);
+    border: 1px solid var(--popup-border);
     border-bottom-width: 2px;
     border-radius: 3px;
     padding: 1px 6px;
     font: inherit;
     font-size: 12px;
-    color: #ffffff;
+    color: var(--popup-fg);
     min-width: 18px;
     text-align: center;
 }

--- a/src/js/help.js
+++ b/src/js/help.js
@@ -1,8 +1,10 @@
-// Help overlay. Lazy-built. Shortcut list: keyboard.js#SHORTCUTS.
-// Credits below mirror /NOTICE and docs/licenses.md.
+// Help overlay. Lazy-built on the shared modal primitive (modal.js).
+// Shortcut list: keyboard.js#SHORTCUTS. Credits mirror /NOTICE and
+// docs/licenses.md.
 
 import { isTypingTarget } from './dom.js';
 import { SHORTCUTS } from './keyboard.js';
+import { createModal } from './modal.js';
 
 const CREDITS = [
     { name: 'libopenmpt',    url: 'https://lib.openmpt.org/libopenmpt/',          license: 'BSD-3' },
@@ -10,33 +12,20 @@ const CREDITS = [
     { name: 'Font Awesome',  url: 'https://fontawesome.com/license/free',         license: 'CC BY 4.0' },
 ];
 
-let overlayEl = null;
-let closeBtnEl = null;
-let isOpen = false;
-
-function buildOverlay() {
-    const node = document.createElement('div');
-    node.id = 'helpOverlay';
-    node.setAttribute('role', 'dialog');
-    node.setAttribute('aria-modal', 'true');
-    node.setAttribute('aria-label', 'Keyboard shortcuts');
-
-    let rows = '';
-    for (const { keys, label, joiner = ' / ' } of SHORTCUTS) {
-        const kbds = keys.map(k => `<kbd>${k}</kbd>`).join(joiner);
-        rows += `<dt>${kbds}</dt><dd>${label}</dd>`;
-    }
-
-    const creditLinks = CREDITS
-        .map(c => `<a href="${c.url}" target="_blank" rel="noopener">${c.name}</a> <span class="help-credits-license">(${c.license})</span>`)
-        .join(' · ');
-
-    node.innerHTML = `
-        <div class="help-card">
-            <h2>
-                <span>Keyboard shortcuts</span>
-                <button type="button" class="help-close" aria-label="Close (Esc)">×</button>
-            </h2>
+const help = createModal({
+    id: 'helpOverlay',
+    title: 'Keyboard shortcuts',
+    className: 'modal-help',
+    build(body) {
+        let rows = '';
+        for (const { keys, label, joiner = ' / ' } of SHORTCUTS) {
+            const kbds = keys.map(k => `<kbd>${k}</kbd>`).join(joiner);
+            rows += `<dt>${kbds}</dt><dd>${label}</dd>`;
+        }
+        const creditLinks = CREDITS
+            .map(c => `<a href="${c.url}" target="_blank" rel="noopener">${c.name}</a> <span class="help-credits-license">(${c.license})</span>`)
+            .join(' · ');
+        body.innerHTML = `
             <dl class="help-list">${rows}</dl>
             <footer class="help-credits">
                 <div class="help-home">
@@ -50,45 +39,18 @@ function buildOverlay() {
                     </a>
                 </div>
                 Built on ${creditLinks}.
-            </footer>
-        </div>
-    `;
+            </footer>`;
+    },
+});
 
-    node.addEventListener('click', e => {
-        if (e.target === node) closeHelp();
-    });
-    closeBtnEl = node.querySelector('.help-close');
-    closeBtnEl.addEventListener('click', closeHelp);
+export function openHelp() { help.open(); }
+export function closeHelp() { help.close(); }
+export function toggleHelp() { help.toggle(); }
 
-    document.body.appendChild(node);
-    return node;
-}
-
-export function openHelp() {
-    if (!overlayEl) overlayEl = buildOverlay();
-    overlayEl.classList.add('visible');
-    isOpen = true;
-    closeBtnEl?.focus();
-}
-
-export function closeHelp() {
-    if (!overlayEl) return;
-    overlayEl.classList.remove('visible');
-    isOpen = false;
-}
-
-export function toggleHelp() {
-    if (isOpen) closeHelp(); else openHelp();
-}
-
+// '?' (Shift+/) — not in the shortcut table; it's a derived shifted key.
+// Esc is handled by the modal primitive.
 export function installHelpEscape() {
     document.addEventListener('keydown', e => {
-        if (e.code === 'Escape' && isOpen) {
-            e.preventDefault();
-            closeHelp();
-            return;
-        }
-        // '?' (Shift+/) — not in the shortcut table; it's a derived shifted key.
         if (e.key === '?' && !isTypingTarget(e.target)) {
             e.preventDefault();
             toggleHelp();

--- a/src/js/modal.js
+++ b/src/js/modal.js
@@ -1,0 +1,101 @@
+// Shared modal primitive. Every popup dialog (help, library, …) is built
+// with createModal() so they share one overlay/card shell, one set of
+// theme-aware styles (.modal-* in style.css) and one behaviour:
+//
+//   - lazy build on first open, content supplied by `build(body, modal)`
+//   - Esc and backdrop click close; only one modal is open at a time
+//   - focus moves into the dialog on open, is trapped inside (Tab cycles)
+//     and returns to the previously focused element on close
+//   - aria: role=dialog, aria-modal, labelled by the title
+//
+// createModal({ id, title, className, width, build, onOpen, onClose })
+//   → { open(), close(), toggle(), isOpen(), el, body }
+
+const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+let current = null;       // the open modal, if any
+let listenerInstalled = false;
+
+function installGlobalListener() {
+    if (listenerInstalled) return;
+    listenerInstalled = true;
+    document.addEventListener('keydown', e => {
+        if (!current) return;
+        if (e.code === 'Escape') {
+            e.preventDefault();
+            current.close();
+            return;
+        }
+        if (e.key === 'Tab') trapTab(e, current.el);
+    });
+}
+
+function trapTab(e, root) {
+    const items = [...root.querySelectorAll(FOCUSABLE)].filter(el => el.offsetParent !== null);
+    if (!items.length) { e.preventDefault(); return; }
+    const first = items[0], last = items[items.length - 1];
+    const active = document.activeElement;
+    if (e.shiftKey && (active === first || !root.contains(active))) { e.preventDefault(); last.focus(); }
+    else if (!e.shiftKey && (active === last || !root.contains(active))) { e.preventDefault(); first.focus(); }
+}
+
+export function createModal({ id, title, className = '', width = null, build, onOpen, onClose }) {
+    let el = null, body = null, titleEl = null;
+    let restoreFocus = null;
+
+    const modal = {
+        get el() { return el; },
+        get body() { return body; },
+        isOpen: () => current === modal,
+        setTitle(html) { if (titleEl) titleEl.innerHTML = html; },
+        open() {
+            if (!el) buildShell();
+            if (current && current !== modal) current.close();
+            restoreFocus = document.activeElement;
+            el.classList.add('visible');
+            current = modal;
+            onOpen?.(modal);
+            // Prefer the first control in the body; fall back to the close button.
+            const target = body.querySelector(FOCUSABLE) || el.querySelector('.modal-close');
+            target?.focus({ preventScroll: true });
+        },
+        close() {
+            if (!el || current !== modal) return;
+            el.classList.remove('visible');
+            current = null;
+            onClose?.(modal);
+            if (restoreFocus && document.contains(restoreFocus)) restoreFocus.focus({ preventScroll: true });
+            restoreFocus = null;
+        },
+        toggle() { if (modal.isOpen()) modal.close(); else modal.open(); },
+    };
+
+    function buildShell() {
+        installGlobalListener();
+        el = document.createElement('div');
+        el.id = id;
+        el.className = `modal-overlay ${className}`.trim();
+        el.setAttribute('role', 'dialog');
+        el.setAttribute('aria-modal', 'true');
+        el.setAttribute('aria-labelledby', `${id}-title`);
+        if (width) el.style.setProperty('--modal-width', width);
+        el.innerHTML = `
+            <div class="modal-card">
+                <h2 class="modal-title"><span id="${id}-title"></span>
+                    <button type="button" class="modal-close" aria-label="Close (Esc)">×</button></h2>
+                <div class="modal-body"></div>
+            </div>`;
+        titleEl = el.querySelector(`#${id}-title`);
+        titleEl.innerHTML = title;
+        body = el.querySelector('.modal-body');
+        el.addEventListener('click', e => { if (e.target === el) modal.close(); });
+        el.querySelector('.modal-close').addEventListener('click', modal.close);
+        document.body.appendChild(el);
+        build?.(body, modal);
+    }
+
+    return modal;
+}
+
+export function closeAnyModal() { current?.close(); }
+export function isAnyModalOpen() { return current !== null; }


### PR DESCRIPTION
→ gamosoft:master


### Why
The help overlay, toasts and the drop-zone card use a fixed dark palette, so on the light themes (Newspaper, Field Journal) and the neon ones they read as foreign objects. Chipsound's whole pitch is that everything is themeable; the dialogs were the exception.

This PR is also groundwork: two follow-up PRs add new dialogs and panels (a Mixer panel for live libopenmpt parameters, and a Library dialog), and I did not want each of them to hard-code its own chrome. So the palette and the dialog shell are factored out here first.

### What
1. **Popup tokens.** `--popup-bg/fg/accent/border/surface/muted/faint/shadow/backdrop` on `:root`, derived from the tracker tokens every theme already defines (`--tracker-bg`, `--tracker-fg`, `--accent`) with `color-mix()`. No theme file changes; a theme can override any popup token if it wants a special look. Help, toast, drop zone and `kbd` read them, and dialog fonts inherit from the body so a serif theme gets a serif dialog.
2. **`modal.js`**, a 110-line dialog shell: lazy build, Esc and backdrop close, one open dialog at a time, focus moves in, Tab is trapped, focus returns to the opener on close, `role=dialog` / `aria-modal` / `aria-labelledby`. Nothing uses it in this commit.
3. **Help overlay on the primitive.** Same public API and `?` key; the help-specific shell CSS goes away. This commit can be dropped on its own if you'd rather keep help as it is; the follow-ups only need commits 1 and 2.

### Notes
- `color-mix()` needs a 2023 browser; the app already requires AudioWorklet and OffscreenCanvas.
- Checked under Newspaper, CRT Green, Mixtape and Field Journal; happy to attach screenshots.


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LZxPVZVBEDisdipGRJfcwn