### PR TITLE
Samples pane fits its content, with a drag handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Other things worth mentioning:
 - Press `T` to cycle themes, `V` to cycle visualizations
 - Click a channel header to mute it; Ctrl-click to solo
 - Subsong picker for modules that ship multiple subsongs
+- The samples pane fits its content; drag its inner edge to resize it (double-click to go back to automatic)
 - `?` opens the full keyboard shortcut list
 
 ## Quick start

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -255,7 +255,10 @@ body { overflow: hidden; }
 
 .tracker-container {
     display: grid;
-    grid-template-columns: 1fr minmax(150px, 25%);
+    /* Samples column fits its content (blank names → narrow, more room for
+       32-channel patterns), capped at 40 % of the row. --samples-col is set
+       inline by pane-resize.js when the user drags the handle. */
+    grid-template-columns: minmax(0, 1fr) var(--samples-col, fit-content(40%));
     gap: 16px;
 }
 /* Stamped on <html> by preboot; kept in sync by toggleSamplesVisible. */
@@ -416,7 +419,45 @@ html.samples-hidden .sample-section    { display: none; }
 
 /* ========== Sample list ========== */
 
-.sample-section { min-width: 0; }
+.sample-section {
+    position: relative;
+    min-width: 120px;
+}
+
+/* Drag handle on the pane's inner edge (sits in the grid gap). */
+.pane-resizer {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: -14px;
+    width: 12px;
+    cursor: col-resize;
+    border-radius: 3px;
+    touch-action: none;
+}
+.sample-section.samples-left .pane-resizer { left: auto; right: -14px; }
+.pane-resizer::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 2px;
+    height: 32px;
+    transform: translate(-50%, -50%);
+    border-radius: 1px;
+    background: var(--tracker-row-highlight);
+    opacity: 0.6;
+    transition: opacity 0.15s ease, background-color 0.15s ease;
+}
+.pane-resizer:hover::after, .pane-resizer.dragging::after, .pane-resizer:focus-visible::after {
+    background: var(--accent);
+    opacity: 1;
+    height: 48px;
+}
+.pane-resizer:focus-visible { outline: none; }
+body.pane-resizing { cursor: col-resize; user-select: none; }
+body.pane-resizing iframe, body.pane-resizing canvas { pointer-events: none; }
+html.samples-hidden .pane-resizer { display: none; }
 
 .sample-list {
     background: var(--tracker-bg);
@@ -698,6 +739,7 @@ kbd {
     .row-label, .header-label { min-width: 30px; font-size: 10px; }
 
     .sample-list { margin-top: 16px; height: auto !important; max-height: 200px; }
+    .pane-resizer { display: none; }
 
     .retro-button { padding: 4px 8px; font-size: 10px; flex: 1 1 calc(50% - 4px); }
 

--- a/src/css/themes/foundry.css
+++ b/src/css/themes/foundry.css
@@ -200,7 +200,7 @@
    class so the pane doesn't flash in on load. `grid-auto-flow: dense` is
    required because .sample-section is the 2nd DOM child pinned to col 1. */
 :root.theme-foundry:not(.samples-hidden) .tracker-container {
-    grid-template-columns: minmax(160px, 22%) 1fr;
+    grid-template-columns: var(--samples-col, fit-content(40%)) minmax(0, 1fr);
     grid-auto-flow: dense;
 }
 :root.theme-foundry:not(.samples-hidden) .tracker-container .sample-section { grid-column: 1; grid-row: 1; }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -29,6 +29,7 @@ import { getChannelVolumes } from './viz-core.js';
 import { installKeyboardShortcuts } from './keyboard.js';
 import { installHelpEscape } from './help.js';
 import { installResizeHandler } from './layout.js';
+import { installSamplesResizer } from './pane-resize.js';
 import { applyTheme, currentTheme, wireThemePicker, prefetchOtherThemes, initThemes } from './themes.js';
 import { placeholderMeta } from './placeholder.js';
 import { installDiagnostics } from './diagnostics.js';
@@ -208,6 +209,7 @@ async function init() {
     installKeyboardShortcuts();
     installHelpEscape();
     installResizeHandler();
+    installSamplesResizer();
 
     applyTheme(currentTheme());
     wireThemePicker();

--- a/src/js/pane-resize.js
+++ b/src/js/pane-resize.js
@@ -1,0 +1,106 @@
+// Samples pane width. By default the pane fits its content (CSS
+// fit-content, capped at 40 % of the row) so blank or short sample names
+// don't waste space that 32-channel patterns could use. A drag handle on
+// the pane's inner edge sets an explicit width (persisted); double-click
+// the handle to go back to automatic.
+
+import { $ } from './dom.js';
+import { prefs } from './prefs.js';
+import { relayoutTracker } from './tracker.js';
+
+const MIN_PX = 120;
+const MAX_FRACTION = 0.6;
+
+let container = null;
+let pane = null;
+let handle = null;
+
+function applyWidth(px) {
+    if (px == null) container.style.removeProperty('--samples-col');
+    else container.style.setProperty('--samples-col', `${Math.round(px)}px`);
+    requestAnimationFrame(() => relayoutTracker());
+}
+
+// Which edge faces the tracker? Themes may put the samples on the left.
+function paneIsLeftOfMain() {
+    const main = $('.tracker-main');
+    if (!main) return false;
+    return pane.getBoundingClientRect().left < main.getBoundingClientRect().left;
+}
+
+function syncHandleSide() {
+    pane.classList.toggle('samples-left', paneIsLeftOfMain());
+}
+
+export function resetSamplesWidth() {
+    prefs.samplesWidth = null;
+    applyWidth(null);
+}
+
+export function installSamplesResizer() {
+    container = $('.tracker-container');
+    pane = $('.sample-section');
+    if (!container || !pane) return;
+
+    handle = document.createElement('div');
+    handle.className = 'pane-resizer';
+    handle.title = 'Drag to resize the samples pane · double-click for automatic width';
+    handle.setAttribute('role', 'separator');
+    handle.setAttribute('aria-orientation', 'vertical');
+    handle.setAttribute('aria-label', 'Resize samples pane');
+    handle.tabIndex = 0;
+    pane.appendChild(handle);
+
+    const saved = prefs.samplesWidth;
+    if (typeof saved === 'number' && saved >= MIN_PX) applyWidth(saved);
+    syncHandleSide();
+    window.addEventListener('resize', syncHandleSide);
+
+    handle.addEventListener('pointerdown', e => {
+        if (e.button !== 0) return;
+        e.preventDefault();
+        syncHandleSide();
+        const left = pane.classList.contains('samples-left');
+        const rect = pane.getBoundingClientRect();
+        const startX = e.clientX;
+        const startW = rect.width;
+        const maxPx = container.getBoundingClientRect().width * MAX_FRACTION;
+        try { handle.setPointerCapture(e.pointerId); } catch { /* synthetic */ }
+        handle.classList.add('dragging');
+        document.body.classList.add('pane-resizing');
+        let pending = null;
+        const move = ev => {
+            const dx = ev.clientX - startX;
+            const w = Math.min(maxPx, Math.max(MIN_PX, left ? startW + dx : startW - dx));
+            pending = w;
+            container.style.setProperty('--samples-col', `${Math.round(w)}px`);
+        };
+        const up = () => {
+            handle.classList.remove('dragging');
+            document.body.classList.remove('pane-resizing');
+            handle.removeEventListener('pointermove', move);
+            handle.removeEventListener('pointerup', up);
+            handle.removeEventListener('pointercancel', up);
+            if (pending != null) { prefs.samplesWidth = Math.round(pending); applyWidth(pending); }
+        };
+        handle.addEventListener('pointermove', move);
+        handle.addEventListener('pointerup', up);
+        handle.addEventListener('pointercancel', up);
+    });
+    handle.addEventListener('dblclick', resetSamplesWidth);
+    handle.addEventListener('keydown', e => {
+        const left = pane.classList.contains('samples-left');
+        const dir = e.key === 'ArrowLeft' ? -1 : e.key === 'ArrowRight' ? 1 : 0;
+        if (dir) {
+            e.preventDefault();
+            const w = pane.getBoundingClientRect().width + dir * (left ? 1 : -1) * (e.shiftKey ? 40 : 10);
+            const maxPx = container.getBoundingClientRect().width * MAX_FRACTION;
+            const clamped = Math.min(maxPx, Math.max(MIN_PX, w));
+            prefs.samplesWidth = Math.round(clamped);
+            applyWidth(clamped);
+        } else if (e.key === 'Home' || e.key === 'Backspace' || e.key === 'Delete') {
+            e.preventDefault();
+            resetSamplesWidth();
+        }
+    });
+}

--- a/src/js/prefs.js
+++ b/src/js/prefs.js
@@ -35,4 +35,8 @@ export const prefs = {
 
     get theme() { return read('theme', 'clusters'); },
     set theme(value) { write('theme', value); },
+
+    // Samples pane width in px; null = fit to content.
+    get samplesWidth() { return read('samplesWidth', null); },
+    set samplesWidth(value) { write('samplesWidth', value); },
 };


### PR DESCRIPTION
→ gamosoft:master


### Why
The samples column is a fixed quarter of the row. Modules with blank or short sample names waste that space, and 32-channel patterns could use it.

### What
- `grid-template-columns: minmax(0,1fr) var(--samples-col, fit-content(40%))`, 120 px floor. On typical modules the pane lands at 185–225 px instead of ~340.
- A drag handle on the pane's inner edge sets `--samples-col` inline, persisted in `localStorage`. Double-click (or Home/Backspace with it focused) returns to automatic; arrows nudge. It flips to the other edge when a theme puts samples on the left.
- Foundry's grid override reads the same property (one line).

### Notes
- Visible default change on the live site: narrower pane on most modules.


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LZxPVZVBEDisdipGRJfcwn