### PR TITLE
Fix pattern prefetch never firing during playback

### DIFF
--- a/src/js/tracker.js
+++ b/src/js/tracker.js
@@ -456,7 +456,7 @@ function centerRow(grid, row) {
 }
 
 // Cancels any in-flight prefetch first; only the latest schedule wins.
-function schedulePrefetch(song, fromOrder) {
+function schedulePrefetch(song, fromOrder, deferrals = 0) {
     cancelPrefetch();
     if (!song || song.totalOrders == null) return;
     const nextOrder = (fromOrder ?? 0) + 1;
@@ -474,10 +474,13 @@ function schedulePrefetch(song, fromOrder) {
         if (targetPattern === activeGrid.patternIndex) return;
         if (targetPattern === prefetchGrid.patternIndex) return;
 
-        // Retry rather than overrun the idle budget.
+        // Prefer a quiet slot, but don't wait forever: while the rAF loop runs
+        // the idle budget peaks near one frame (~16 ms), and a cold miss at
+        // the boundary would cost the same build inside a playback frame.
         if (deadline && typeof deadline.timeRemaining === 'function'
-            && deadline.timeRemaining() < PREFETCH_MIN_BUDGET_MS) {
-            schedulePrefetch(song, fromOrder);
+            && deadline.timeRemaining() < PREFETCH_MIN_BUDGET_MS
+            && deferrals < PREFETCH_MAX_DEFERRALS) {
+            schedulePrefetch(song, fromOrder, deferrals + 1);
             return;
         }
         populateGrid(prefetchGrid, song, targetPattern);
@@ -495,7 +498,8 @@ function schedulePrefetch(song, fromOrder) {
     }
 }
 
-const PREFETCH_MIN_BUDGET_MS = 20;
+const PREFETCH_MIN_BUDGET_MS = 8;
+const PREFETCH_MAX_DEFERRALS = 4;
 
 function cancelPrefetch() {
     if (prefetchIdleHandle === -1) return;


### PR DESCRIPTION
Fixes #8.

### Why
`schedulePrefetch` requires a 20 ms idle budget before it will build the next pattern's grid. While the animation loop runs, `requestIdleCallback` hands out at most about one frame (measured 11–16.5 ms), so the bar is never met, the callback reschedules itself forever, and every pattern change takes the cold path: a synchronous `innerHTML` build inside the playback frame. Details and a repro are in #8.

### What
- `PREFETCH_MIN_BUDGET_MS` 20 → 8.
- Stop deferring after four tries (`PREFETCH_MAX_DEFERRALS`), passed along as a parameter so each fresh schedule starts at zero.

Nine lines in `tracker.js`, no behaviour change beyond the prefetch actually happening.

### Verified
Same observer as in #8, Chromium, `aryx.s3m`: the next pattern is built ~15 ms after each boundary swap, and the following boundary is a pure swap with no rebuild. `getPatternCacheSize()` sits at 2 during playback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LZxPVZVBEDisdipGRJfcwn
